### PR TITLE
refactor(android): update package namespace from sms_to_api to smstoapi

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.github.dilrandi.sms_to_api"
+    namespace = "com.github.dilrandi.smstoapi"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.github.dilrandi.sms_to_api"
+        applicationId = "com.github.dilrandi.smstoapi"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 25

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/LogManager.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/LogManager.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 
 import android.Manifest
@@ -18,8 +18,8 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
-    private val serviceChannelName = "com.github.dilrandi.sms_to_api_service/sms_forwarding"
-    private val settingsChannelName = "com.github.dilrandi.sms_to_api/settings"
+    private val serviceChannelName = "com.github.dilrandi.smstoapi_service/sms_forwarding"
+    private val settingsChannelName = "com.github.dilrandi.smstoapi/settings"
     private lateinit var serviceChannel: MethodChannel
     private lateinit var settingsChannel: MethodChannel
 

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/PermissionCheckWorker.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/PermissionCheckWorker.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.Manifest
 import android.app.NotificationChannel

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/PermissionMonitor.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/PermissionMonitor.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.content.Context
 import androidx.work.Constraints

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SecureSettingsBridge.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SecureSettingsBridge.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingService.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingService.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -189,6 +189,6 @@ class SmsForwardingService : Service() {
     companion object {
         const val CHANNEL_ID = "SmsForwardingServiceChannel"
         const val NOTIFICATION_ID = 101 // Unique ID for your notification
-        const val ACTION_FORWARD_SMS_TO_API = "com.github.dilrandi.sms_to_api.FORWARD_SMS_TO_API"
+        const val ACTION_FORWARD_SMS_TO_API = "com.github.dilrandi.smstoapi.FORWARD_SMS_TO_API"
     }
 }

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingTask.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingTask.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.content.Context
 import kotlinx.coroutines.Dispatchers

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingWorker.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsForwardingWorker.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.content.Context
 import androidx.work.Constraints

--- a/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsReceiver.kt
+++ b/android/app/src/main/kotlin/com/github/dilrandi/smstoapi/SmsReceiver.kt
@@ -1,4 +1,4 @@
-package com.github.dilrandi.sms_to_api
+package com.github.dilrandi.smstoapi
 
 import android.Manifest
 import android.content.BroadcastReceiver

--- a/lib/screen/home.dart
+++ b/lib/screen/home.dart
@@ -78,7 +78,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   static const MethodChannel _channel = MethodChannel(
-    'com.github.dilrandi.sms_to_api_service/sms_forwarding',
+    'com.github.dilrandi.smstoapi_service/sms_forwarding',
   );
 
   String _serviceStatus = 'Not Running'; // Initial status

--- a/lib/storage/settings/storage.dart
+++ b/lib/storage/settings/storage.dart
@@ -9,7 +9,7 @@ class Storage {
       : _channel = channel ?? const MethodChannel(channelName);
 
   static const String channelName =
-      'com.github.dilrandi.sms_to_api/settings';
+      'com.github.dilrandi.smstoapi/settings';
   static const String _legacySettingsKey = 'settings_data';
   final MethodChannel _channel;
 


### PR DESCRIPTION
Remove underscores from package identifiers to follow Android naming conventions.

Changes:
- Update Android namespace and applicationId in build.gradle.kts
- Update MethodChannel names in Dart code to match new package structure
- Affects service communication channel and settings storage channel

This ensures consistency across the codebase and aligns with standard Android package naming practices that discourage underscores in package names.